### PR TITLE
Add getOrNil extension to Array

### DIFF
--- a/Extended/Classes/Array.swift
+++ b/Extended/Classes/Array.swift
@@ -30,4 +30,15 @@ extension Array {
         }
         return array
     }
+    
+    
+    /// Retrieves the element at the given index or nil if the index is invalid
+    func getOrNil(_ index: Int) -> Element? {
+        if 0 ..< self.count ~= index {
+            return self[index]
+        } else {
+            return nil
+        }
+    }
+    
 }


### PR DESCRIPTION
This commit adds a convenience method for avoiding index of out bounds
runtime errors. If the index is invalid, you will safely be returned
nil.